### PR TITLE
Cache html from RBG

### DIFF
--- a/api/CacheAccess.php
+++ b/api/CacheAccess.php
@@ -1,0 +1,14 @@
+<?php
+
+class CacheAccess
+{
+    static function getHtml($url){
+        if(apcu_exists($url)){
+            $html = apcu_fetch($url);
+        }else{
+            $html = file_get_html($url);
+            apcu_add($url, $html, 60);
+        }
+        return $html;
+    }
+}

--- a/api/CacheAccess.php
+++ b/api/CacheAccess.php
@@ -2,12 +2,19 @@
 
 class CacheAccess
 {
-    static function getHtml($url){
+
+    /**
+     * Loads html from url or cache, if present.
+     * @param $url
+     * @param int $ttl
+     * @return false|file_get_html|mixed
+     */
+    static function getHtml($url, $ttl = 60){
         if(apcu_exists($url)){
             $html = apcu_fetch($url);
         }else{
             $html = file_get_html($url);
-            apcu_add($url, $html, 60);
+            apcu_add($url, $html, $ttl);
         }
         return $html;
     }

--- a/api/get_rbg_hls_link.php
+++ b/api/get_rbg_hls_link.php
@@ -3,7 +3,7 @@ include 'simple_html_dom.php';
 include_once 'CacheAccess.php';
 
 function get_rbg_hls_link(string $url): ?string {
-  $html = CacheAccess::getHtml($url, 60, 60*60*24); // this site should be static, therefore we cache it longer.
+  $html = CacheAccess::getHtml($url, 60*60*24); // this site should be static, therefore we cache it longer.
 
   if($html) {
     $matches = array();

--- a/api/get_rbg_hls_link.php
+++ b/api/get_rbg_hls_link.php
@@ -1,8 +1,9 @@
 <?php
 include 'simple_html_dom.php';
+include_once 'CacheAccess.php';
 
 function get_rbg_hls_link(string $url): ?string {
-  $html = file_get_html($url);
+  $html = CacheAccess::getHtml($url);
 
   if($html) {
     $matches = array();

--- a/api/get_rbg_hls_link.php
+++ b/api/get_rbg_hls_link.php
@@ -3,7 +3,7 @@ include 'simple_html_dom.php';
 include_once 'CacheAccess.php';
 
 function get_rbg_hls_link(string $url): ?string {
-  $html = CacheAccess::getHtml($url);
+  $html = CacheAccess::getHtml($url, 60, 60*60*24); // this site should be static, therefore we cache it longer.
 
   if($html) {
     $matches = array();

--- a/api/get_rbg_stream_site.php
+++ b/api/get_rbg_stream_site.php
@@ -1,11 +1,11 @@
 <?php
 include 'simple_html_dom.php';
+include_once 'CacheAccess.php';
 
 function ParseInformation($link)
 {
     // First get html of remote page
-    $html = file_get_html($link);
-
+    $html = CacheAccess::getHtml($link);
 
     $veranstaltung =  $html->find("main", 1)->find("font", 0)->find("b", 0)->innertext;
     $date =  $html->find("main", 1)->find("font", 0)->find("b", 1)->innertext;

--- a/api/get_rbg_streams.php
+++ b/api/get_rbg_streams.php
@@ -1,9 +1,9 @@
 <?php
 include 'simple_html_dom.php';
-
+include_once 'CacheAccess.php';
 // First get html of remote page
 $URL = "https://live.rbg.tum.de/cgi-bin/streams";
-$html = file_get_html($URL);
+$html = CacheAccess::getHtml($URL);
 
 // Initialize basic data structure
 $data = array();


### PR DESCRIPTION
This way live.rbg.tum.de is loaded at most once a minute. @kordianbruck, is that too often? If I recall correctly, streams appear ~5 minutes before they start, we don't want people to miss the beginning of a lecture. 

I only cached the html here instead of the parsed data because this way the different API endpoints can share some of my new code. If you guys think we should cache everything that's done in a few minutes :)

This fixes #4